### PR TITLE
Add realtime socket server

### DIFF
--- a/realtime-service/package.json
+++ b/realtime-service/package.json
@@ -2,7 +2,7 @@
   "name": "realtime-service",
   "version": "1.0.0",
   "description": "",
-  "main": "index.js",
+  "main": "server.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/realtime-service/server.js
+++ b/realtime-service/server.js
@@ -1,0 +1,51 @@
+process.env.TS_NODE_COMPILER_OPTIONS = JSON.stringify({
+  module: 'es2022',
+  esModuleInterop: true,
+  target: 'es2020',
+  moduleResolution: 'node'
+});
+require('ts-node/register');
+
+const express = require('express');
+const http = require('http');
+const cors = require('cors');
+const { Server } = require('socket.io');
+
+const { realWebSocketFeeds } = require('./RealWebSocketFeeds');
+
+// Start real websocket feeds
+realWebSocketFeeds.start();
+
+const app = express();
+app.use(cors());
+
+const httpServer = http.createServer(app);
+const io = new Server(httpServer, {
+  cors: {
+    origin: '*',
+    methods: ['GET', 'POST']
+  }
+});
+
+realWebSocketFeeds.onTick((tick) => {
+  io.emit('tick', tick);
+});
+
+io.on('connection', (socket) => {
+  console.log(`🟢 Cliente conectado: ${socket.id}`);
+  socket.emit('connected', { message: 'Conexión establecida con el servicio realtime' });
+  socket.on('disconnect', () => {
+    console.log(`🔴 Cliente desconectado: ${socket.id}`);
+  });
+});
+
+app.get('/stats', (req, res) => {
+  const stats = realWebSocketFeeds.getConnectionStats();
+  const lastTicks = realWebSocketFeeds.getLastTicks(10);
+  res.json({ stats, lastTicks });
+});
+
+const PORT = process.env.REALTIME_PORT || 3001;
+httpServer.listen(PORT, () => {
+  console.log(`🚀 Servicio realtime escuchando en el puerto ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- implement `realtime-service/server.js` to broadcast real exchange ticks via Socket.IO
- set `server.js` as main entry in realtime-service package.json

## Testing
- `npm install`
- `cd realtime-service && npm install`
- `node server.js` *(fails to connect to exchanges due to ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_6884b2ff21d48332a085aad5bdce68c4